### PR TITLE
Frontend Docker polish: .dockerignore, NODE_ENV, better caching

### DIFF
--- a/frontend/web/.dockerignore
+++ b/frontend/web/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/frontend/web/Dockerfile
+++ b/frontend/web/Dockerfile
@@ -1,10 +1,17 @@
-FROM node:20 AS build
+# Build
+FROM node:20-alpine AS build
 WORKDIR /app
-COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
-RUN if [ -f package-lock.json ]; then npm ci;     elif [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i;     elif [ -f yarn.lock ]; then yarn;     else npm i; fi
+
+# Better cache: copy only manifests first, install, then copy src
+COPY package*.json ./
+ENV NODE_ENV=production
+RUN npm ci
+
 COPY . .
 RUN npm run build
+
+# Serve
 FROM nginx:1.27-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
-CMD ["nginx","-g","daemon off;"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/web/Dockerfile
+++ b/frontend/web/Dockerfile
@@ -1,17 +1,41 @@
 # Build
 FROM node:20-alpine AS build
 WORKDIR /app
+<<<<<<< Updated upstream
 
 # Better cache: copy only manifests first, install, then copy src
 COPY package*.json ./
 ENV NODE_ENV=production
 RUN npm ci
 
+||||||| constructed merge base
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+RUN if [ -f package-lock.json ]; then npm ci;     elif [ -f pnpm-lock.yaml ]; then npm i -g pnpm && pnpm i;     elif [ -f yarn.lock ]; then yarn;     else npm i; fi
+=======
+
+# Cache-friendly install
+COPY package*.json ./
+RUN npm ci
+
+# Copy source and build with production optimizations
+>>>>>>> Stashed changes
 COPY . .
+<<<<<<< Updated upstream
 RUN npm run build
 
 # Serve
+||||||| constructed merge base
+RUN npm run build
+=======
+RUN NODE_ENV=production npm run build
+
+# Serve
+>>>>>>> Stashed changes
 FROM nginx:1.27-alpine
+
+# SPA config
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/web/nginx.conf
+++ b/frontend/web/nginx.conf
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|woff2?)$ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    try_files $uri =404;
+  }
+}


### PR DESCRIPTION
# Frontend Docker polish: .dockerignore, NODE_ENV, better caching

## Summary
Small optimization improvements to the frontend Docker build:
- Added `.dockerignore` to exclude `node_modules`, `dist`, and `.git` from build context
- Switched to Alpine Linux base image for smaller size (`node:20-alpine`)
- Set `NODE_ENV=production` for production builds
- Simplified package management to use only `npm ci` (removed pnpm/yarn support)
- Added build comments and improved formatting

## Review & Testing Checklist for Human
- [ ] **Docker build verification**: Run `docker build frontend/web` to ensure the build completes successfully
- [ ] **Application functionality**: Start the built container and verify the web app loads and functions correctly in browser
- [ ] **Package manager compatibility**: Confirm this project uses npm (not pnpm/yarn) since multi-package-manager support was removed

### Notes
- Alpine Linux images are smaller but occasionally have compatibility issues with native dependencies
- `NODE_ENV=production` during build is generally good practice but could theoretically affect build behavior
- Build layer caching should now be more efficient due to manifest-first copying

**Requested by:** @Alsairy  
**Link to Devin run:** https://app.devin.ai/sessions/e4620343536744f1a9df1a838ee4be65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Excluded node_modules, build output, and VCS data from container build context to reduce image size and build time.

- Refactor
  - Switched to a lighter base image and implemented a multi-stage build that separates build and serve phases for smaller deploys.

- New Features
  - App is served by a lightweight web server on port 80 with SPA routing.

- Style
  - Improved container config readability and command formatting; static assets now receive long-term caching headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->