### PR TITLE
Deploy: GKE manifests + GCP deployment docs

### DIFF
--- a/deploy/k8s/api-deployment.yaml
+++ b/deploy/k8s/api-deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-api
+  labels:
+    app: assets-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: assets-api
+  template:
+    metadata:
+      labels:
+        app: assets-api
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          image: ghcr.io/alsairy/assets_platform/api:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: ASPNETCORE_URLS
+              value: http://+:8080
+            - name: OIDC__AUTHORITY
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: OIDC_AUTHORITY
+            - name: FLOWABLE__BASEURL
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: FLOWABLE_BASEURL
+            - name: FLOWABLE__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: assets-secrets
+                  key: FLOWABLE_USERNAME
+            - name: FLOWABLE__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: assets-secrets
+                  key: FLOWABLE_PASSWORD
+            - name: OCR__PROVIDER
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: OCR_PROVIDER
+            - name: OCR__CONFIDENCETHRESHOLD
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: OCR_CONFIDENCE_THRESHOLD
+            - name: GoogleCloud__ProjectId
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: GOOGLE_PROJECT_ID
+            - name: GCS__BucketName
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: GCS_BUCKET
+            - name: ConnectionStrings__Default
+              valueFrom:
+                secretKeyRef:
+                  name: assets-secrets
+                  key: CONNECTION_STRING
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ "ALL" ]

--- a/deploy/k8s/api-service.yaml
+++ b/deploy/k8s/api-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: assets-api
+  labels:
+    app: assets-api
+spec:
+  selector:
+    app: assets-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+  type: ClusterIP

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: assets-config
+data:
+  OIDC_AUTHORITY: "https://keycloak.example.com/realms/moe"
+  FLOWABLE_BASEURL: "http://flowable-rest.flowable.svc.cluster.local:8080/flowable-rest"
+  OCR_PROVIDER: "Google"
+  OCR_CONFIDENCE_THRESHOLD: "0.85"
+  GOOGLE_PROJECT_ID: "your-gcp-project-id"
+  GCS_BUCKET: "assets-docs"

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: assets-api
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "20m"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - assets.example.com
+      secretName: assets-tls
+  rules:
+    - host: assets.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: assets-api
+                port:
+                  number: 80

--- a/deploy/k8s/secrets.template.yaml
+++ b/deploy/k8s/secrets.template.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: assets-secrets
+type: Opaque
+stringData:
+  CONNECTION_STRING: "Host=postgres;Port=5432;Database=appdb;Username=app;Password=app"
+  FLOWABLE_USERNAME: "rest-admin"
+  FLOWABLE_PASSWORD: "test"

--- a/deploy/k8s/worker-deployment.yaml
+++ b/deploy/k8s/worker-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-ocr-worker
+  labels:
+    app: assets-ocr-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: assets-ocr-worker
+  template:
+    metadata:
+      labels:
+        app: assets-ocr-worker
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: worker
+          image: ghcr.io/alsairy/assets_platform/api:latest
+          imagePullPolicy: IfNotPresent
+          args: ["--run-worker=OcrJobWorker"]
+          env:
+            - name: ASPNETCORE_URLS
+              value: http://+:8080
+            - name: OIDC__AUTHORITY
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: OIDC_AUTHORITY
+            - name: FLOWABLE__BASEURL
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: FLOWABLE_BASEURL
+            - name: FLOWABLE__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: assets-secrets
+                  key: FLOWABLE_USERNAME
+            - name: FLOWABLE__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: assets-secrets
+                  key: FLOWABLE_PASSWORD
+            - name: OCR__PROVIDER
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: OCR_PROVIDER
+            - name: OCR__CONFIDENCETHRESHOLD
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: OCR_CONFIDENCE_THRESHOLD
+            - name: GoogleCloud__ProjectId
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: GOOGLE_PROJECT_ID
+            - name: GCS__BucketName
+              valueFrom:
+                configMapKeyRef:
+                  name: assets-config
+                  key: GCS_BUCKET
+            - name: ConnectionStrings__Default
+              valueFrom:
+                secretKeyRef:
+                  name: assets-secrets
+                  key: CONNECTION_STRING
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ "ALL" ]

--- a/docs/deployment/environments.md
+++ b/docs/deployment/environments.md
@@ -1,0 +1,10 @@
+# Environments and topology
+
+- API: ASP.NET Core (port 8080)
+- Worker: OcrJobWorker as separate Deployment
+- Keycloak: external cluster/service
+- Flowable REST: external or shared namespace
+- DB: Cloud SQL for Postgres
+- Object storage: GCS (bucket: assets-docs)
+
+Config via ConfigMap; secrets via Secret or Workload Identity. Scale API with HPA on CPU/P95; Worker with queue depth or CPU.

--- a/docs/deployment/observability.md
+++ b/docs/deployment/observability.md
@@ -1,0 +1,5 @@
+# Observability
+
+- Logs: structured JSON via Serilog; include correlation IDs.
+- Metrics: request rate/latency, worker jobs (started/succeeded/failed/low_confidence).
+- Alerts: API 5xx, latency SLO breaches, worker failures > threshold, DB CPU > 80%, storage errors.

--- a/docs/deployment/runbooks.md
+++ b/docs/deployment/runbooks.md
@@ -1,0 +1,6 @@
+# Runbooks
+
+- Cloud SQL PITR: scale API/worker to 0, restore into new instance, update CONNECTION_STRING, run migrations, scale up, verify.
+- Worker backlog drain: scale to 0, resume with 1 replica, monitor job statuses.
+- Flowable stuck workflows: check management endpoint, retry or move to error state.
+- Keycloak outage: tokens cached briefly; degrade reads; disable strict audience in emergencies.

--- a/docs/deployment/secrets.md
+++ b/docs/deployment/secrets.md
@@ -1,0 +1,16 @@
+# Secrets and configuration
+
+ConfigMap (non-sensitive):
+- OIDC_AUTHORITY
+- FLOWABLE_BASEURL
+- OCR_PROVIDER
+- OCR_CONFIDENCE_THRESHOLD
+- GOOGLE_PROJECT_ID
+- GCS_BUCKET
+
+Secret (sensitive):
+- CONNECTION_STRING
+- FLOWABLE_USERNAME
+- FLOWABLE_PASSWORD
+
+Prefer Workload Identity instead of key files for Google SDKs.


### PR DESCRIPTION
# Deploy: GKE manifests + GCP deployment docs

## Summary
Adds production-ready Kubernetes manifests for GKE deployment and comprehensive deployment documentation. This includes separate API and OCR worker deployments with security hardening, ConfigMap/Secret separation, and operational runbooks for Cloud SQL, Flowable, and Keycloak scenarios.

**Key additions:**
- API deployment with health checks, security context, and environment wiring
- Separate OCR worker deployment for background processing
- Service, Ingress (with TLS), ConfigMap, and Secrets template
- Documentation covering topology, secrets management, runbooks, and observability

## Review & Testing Checklist for Human
- [ ] **Verify worker deployment args**: The worker uses `args: ["--run-worker=OcrJobWorker"]` - confirm the API actually supports this argument format
- [ ] **Test manifests in cluster**: Run `kubectl apply --dry-run=server -f deploy/k8s/` and deploy to verify they work end-to-end
- [ ] **Update placeholder values**: Replace example.com hosts, project IDs, and other placeholders in configmap.yaml and ingress.yaml
- [ ] **Check readOnlyRootFilesystem compatibility**: ASP.NET Core may need temp file writes - test if this security setting breaks the app
- [ ] **Add resource limits**: Consider adding CPU/memory requests/limits to deployments for production use

### Notes
Security hardening includes `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and dropped capabilities. External dependencies (Keycloak, Flowable, Cloud SQL) are referenced but not included - you'll need to deploy those separately.

Link to Devin run: https://app.devin.ai/sessions/e4620343536744f1a9df1a838ee4be65
Requested by: @Alsairy