### PR TITLE
feat(k8s): Kustomize base/overlays (dev/staging/prod) + HPA/PDB/NetPol + CI render + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,47 @@ jobs:
           file: ./backend/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}/api:${{ github.sha }}
+  render-manifests:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install kustomize
+        run: |
+          curl -sL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.4.1/kustomize_v5.4.1_linux_amd64.tar.gz | tar xz
+          sudo mv kustomize /usr/local/bin/kustomize
+      - name: Install kubeconform
+        run: |
+          curl -sL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/kubeconform
+      - name: Render dev
+        env:
+          VERSION: ${{ github.sha }}
+        run: |
+          sed -i "s/{{VERSION}}/${VERSION}/g" deploy/k8s/base/kustomization.yaml
+          kustomize build deploy/k8s/overlays/dev > manifests-dev.yaml
+          kubeconform -strict -summary manifests-dev.yaml
+          git checkout -- deploy/k8s/base/kustomization.yaml
+      - name: Render staging
+        env:
+          VERSION: ${{ github.sha }}
+        run: |
+          sed -i "s/{{VERSION}}/${VERSION}/g" deploy/k8s/base/kustomization.yaml
+          kustomize build deploy/k8s/overlays/staging > manifests-staging.yaml
+          kubeconform -strict -summary manifests-staging.yaml
+          git checkout -- deploy/k8s/base/kustomization.yaml
+      - name: Render prod
+        env:
+          VERSION: ${{ github.sha }}
+        run: |
+          sed -i "s/{{VERSION}}/${VERSION}/g" deploy/k8s/base/kustomization.yaml
+          kustomize build deploy/k8s/overlays/prod > manifests-prod.yaml
+          kubeconform -strict -summary manifests-prod.yaml
+          git checkout -- deploy/k8s/base/kustomization.yaml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: k8s-manifests
+          path: |
+            manifests-dev.yaml
+            manifests-staging.yaml
+            manifests-prod.yaml

--- a/deploy/k8s/base/api-deployment.yaml
+++ b/deploy/k8s/base/api-deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-api
+  labels:
+    app: assets
+    component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: assets
+      component: api
+  template:
+    metadata:
+      labels:
+        app: assets
+        component: api
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: api
+          image: ghcr.io/alsairy/assets_platform/api:{{VERSION}}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef: { name: assets-config }
+            - secretRef:    { name: assets-secrets }
+          readinessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          startupProbe:
+            httpGet: { path: /health, port: 8080 }
+            failureThreshold: 30
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: tmp,            mountPath: /tmp }
+            - { name: dataprotection, mountPath: /home/app/.aspnet/DataProtection-Keys }
+      volumes:
+        - { name: tmp,            emptyDir: {} }
+        - { name: dataprotection, emptyDir: {} }

--- a/deploy/k8s/base/api-service.yaml
+++ b/deploy/k8s/base/api-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: assets-api
+  labels:
+    app: assets
+    component: api
+spec:
+  type: ClusterIP
+  selector:
+    app: assets
+    component: api
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: assets-config
+data:
+  OIDC__AUTHORITY: "https://idp.example.com/realms/moe"
+  OIDC__AUDIENCE: "assets-api"
+  Flowable__BaseUrl: "https://flowable.example.com/flowable-rest"
+  OCR__PROVIDER: "Google"
+  OCR__CONFIDENCETHRESHOLD: "0.85"
+  GoogleCloud__ProjectId: "your-gcp-project"
+  GCS__BucketName: "your-gcs-bucket"

--- a/deploy/k8s/base/ingress.yaml
+++ b/deploy/k8s/base/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: assets-api
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "20m"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: assets.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: assets-api
+                port: { number: 80 }
+  tls:
+    - hosts: ["assets.example.com"]
+      secretName: assets-tls

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - api-deployment.yaml
+  - worker-deployment.yaml
+  - api-service.yaml
+  - ingress.yaml
+  - configmap.yaml
+  - secrets.template.yaml
+images:
+  - name: ghcr.io/alsairy/assets_platform/api
+    newName: ghcr.io/alsairy/assets_platform/api
+    newTag: "{{VERSION}}"
+  - name: ghcr.io/alsairy/assets_platform/worker
+    newName: ghcr.io/alsairy/assets_platform/worker
+    newTag: "{{VERSION}}"

--- a/deploy/k8s/base/secrets.template.yaml
+++ b/deploy/k8s/base/secrets.template.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: assets-secrets
+type: Opaque
+stringData:
+  ConnectionStrings__Default: "Host=127.0.0.1;Port=5432;Database=appdb;Username=CHANGE_ME;Password=CHANGE_ME"
+  Flowable__Username: "CHANGE_ME"
+  Flowable__Password: "CHANGE_ME"

--- a/deploy/k8s/base/worker-deployment.yaml
+++ b/deploy/k8s/base/worker-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-worker
+  labels:
+    app: assets
+    component: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: assets
+      component: worker
+  template:
+    metadata:
+      labels:
+        app: assets
+        component: worker
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+        - name: worker
+          image: ghcr.io/alsairy/assets_platform/worker:{{VERSION}}
+          imagePullPolicy: IfNotPresent
+          args: ["--run-worker=OcrJobWorker"]
+          envFrom:
+            - configMapRef: { name: assets-config }
+            - secretRef:    { name: assets-secrets }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: tmp, mountPath: /tmp }
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "256Mi"
+            limits:
+              cpu: "800m"
+              memory: "512Mi"
+          livenessProbe:
+            exec: { command: ["sh","-c","echo ok"] }
+            initialDelaySeconds: 30
+            periodSeconds: 30
+      volumes:
+        - { name: tmp, emptyDir: {} }

--- a/deploy/k8s/overlays/dev/hpa-api.yaml
+++ b/deploy/k8s/overlays/dev/hpa-api.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: assets-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: assets-api
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/deploy/k8s/overlays/dev/hpa-worker.yaml
+++ b/deploy/k8s/overlays/dev/hpa-worker.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: assets-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: assets-worker
+  minReplicas: 1
+  maxReplicas: 2
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: assets-dev
+resources:
+  - ../../base
+  - hpa-api.yaml
+  - hpa-worker.yaml
+  - pdb-api.yaml
+  - pdb-worker.yaml
+  - netpol-default-deny-egress.yaml
+  - netpol-allow-ingress-to-api.yaml
+  - netpol-allow-api-egress.yaml
+  - netpol-allow-worker-egress.yaml
+patches:
+  - path: patch-deploy-api-replicas.yaml
+  - path: patch-deploy-worker-replicas.yaml
+  - path: patch-ingress.yaml
+images:
+  - name: ghcr.io/alsairy/assets_platform/api
+    newTag: "{{VERSION}}"
+  - name: ghcr.io/alsairy/assets_platform/worker
+    newTag: "{{VERSION}}"
+configMapGenerator:
+  - name: assets-config
+    behavior: merge
+    literals:
+      - OIDC__AUTHORITY=https://idp.dev.example.com/realms/moe
+      - OIDC__AUDIENCE=assets-api
+      - Flowable__BaseUrl=https://flowable.dev.example.com/flowable-rest
+      - GoogleCloud__ProjectId=dev-gcp-project
+      - GCS__BucketName=dev-gcs-bucket

--- a/deploy/k8s/overlays/dev/netpol-allow-api-egress.yaml
+++ b/deploy/k8s/overlays/dev/netpol-allow-api-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: api
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/deploy/k8s/overlays/dev/netpol-allow-ingress-to-api.yaml
+++ b/deploy/k8s/overlays/dev/netpol-allow-ingress-to-api.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-api
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx

--- a/deploy/k8s/overlays/dev/netpol-allow-worker-egress.yaml
+++ b/deploy/k8s/overlays/dev/netpol-allow-worker-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-worker-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: worker
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/deploy/k8s/overlays/dev/netpol-default-deny-egress.yaml
+++ b/deploy/k8s/overlays/dev/netpol-default-deny-egress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/deploy/k8s/overlays/dev/patch-deploy-api-replicas.yaml
+++ b/deploy/k8s/overlays/dev/patch-deploy-api-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-api
+spec:
+  replicas: 1

--- a/deploy/k8s/overlays/dev/patch-deploy-worker-replicas.yaml
+++ b/deploy/k8s/overlays/dev/patch-deploy-worker-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-worker
+spec:
+  replicas: 1

--- a/deploy/k8s/overlays/dev/patch-ingress.yaml
+++ b/deploy/k8s/overlays/dev/patch-ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: assets-api
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: assets.dev.example.com
+  tls:
+    - hosts: ["assets.dev.example.com"]
+      secretName: assets-dev-tls

--- a/deploy/k8s/overlays/dev/pdb-api.yaml
+++ b/deploy/k8s/overlays/dev/pdb-api.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: assets-api
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: assets
+      component: api

--- a/deploy/k8s/overlays/dev/pdb-worker.yaml
+++ b/deploy/k8s/overlays/dev/pdb-worker.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: assets-worker
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: assets
+      component: worker

--- a/deploy/k8s/overlays/prod/hpa-api.yaml
+++ b/deploy/k8s/overlays/prod/hpa-api.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: assets-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: assets-api
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/deploy/k8s/overlays/prod/hpa-worker.yaml
+++ b/deploy/k8s/overlays/prod/hpa-worker.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: assets-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: assets-worker
+  minReplicas: 2
+  maxReplicas: 8
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: assets-prod
+resources:
+  - ../../base
+  - hpa-api.yaml
+  - hpa-worker.yaml
+  - pdb-api.yaml
+  - pdb-worker.yaml
+  - netpol-default-deny-egress.yaml
+  - netpol-allow-ingress-to-api.yaml
+  - netpol-allow-api-egress.yaml
+  - netpol-allow-worker-egress.yaml
+patches:
+  - path: patch-deploy-api-replicas.yaml
+  - path: patch-deploy-worker-replicas.yaml
+  - path: patch-ingress.yaml
+images:
+  - name: ghcr.io/alsairy/assets_platform/api
+    newTag: "{{VERSION}}"
+  - name: ghcr.io/alsairy/assets_platform/worker
+    newTag: "{{VERSION}}"
+configMapGenerator:
+  - name: assets-config
+    behavior: merge
+    literals:
+      - OIDC__AUTHORITY=https://idp.prod.example.com/realms/moe
+      - OIDC__AUDIENCE=assets-api
+      - Flowable__BaseUrl=https://flowable.prod.example.com/flowable-rest
+      - GoogleCloud__ProjectId=prod-gcp-project
+      - GCS__BucketName=prod-gcs-bucket

--- a/deploy/k8s/overlays/prod/netpol-allow-api-egress.yaml
+++ b/deploy/k8s/overlays/prod/netpol-allow-api-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: api
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/deploy/k8s/overlays/prod/netpol-allow-ingress-to-api.yaml
+++ b/deploy/k8s/overlays/prod/netpol-allow-ingress-to-api.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-api
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx

--- a/deploy/k8s/overlays/prod/netpol-allow-worker-egress.yaml
+++ b/deploy/k8s/overlays/prod/netpol-allow-worker-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-worker-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: worker
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/deploy/k8s/overlays/prod/netpol-default-deny-egress.yaml
+++ b/deploy/k8s/overlays/prod/netpol-default-deny-egress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/deploy/k8s/overlays/prod/patch-deploy-api-replicas.yaml
+++ b/deploy/k8s/overlays/prod/patch-deploy-api-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-api
+spec:
+  replicas: 3

--- a/deploy/k8s/overlays/prod/patch-deploy-worker-replicas.yaml
+++ b/deploy/k8s/overlays/prod/patch-deploy-worker-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-worker
+spec:
+  replicas: 2

--- a/deploy/k8s/overlays/prod/patch-ingress.yaml
+++ b/deploy/k8s/overlays/prod/patch-ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: assets-api
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: assets.example.com
+  tls:
+    - hosts: ["assets.example.com"]
+      secretName: assets-prod-tls

--- a/deploy/k8s/overlays/prod/pdb-api.yaml
+++ b/deploy/k8s/overlays/prod/pdb-api.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: assets-api
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: assets
+      component: api

--- a/deploy/k8s/overlays/prod/pdb-worker.yaml
+++ b/deploy/k8s/overlays/prod/pdb-worker.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: assets-worker
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: assets
+      component: worker

--- a/deploy/k8s/overlays/staging/hpa-api.yaml
+++ b/deploy/k8s/overlays/staging/hpa-api.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: assets-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: assets-api
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/deploy/k8s/overlays/staging/hpa-worker.yaml
+++ b/deploy/k8s/overlays/staging/hpa-worker.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: assets-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: assets-worker
+  minReplicas: 1
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/deploy/k8s/overlays/staging/kustomization.yaml
+++ b/deploy/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: assets-staging
+resources:
+  - ../../base
+  - hpa-api.yaml
+  - hpa-worker.yaml
+  - pdb-api.yaml
+  - pdb-worker.yaml
+  - netpol-default-deny-egress.yaml
+  - netpol-allow-ingress-to-api.yaml
+  - netpol-allow-api-egress.yaml
+  - netpol-allow-worker-egress.yaml
+patches:
+  - path: patch-deploy-api-replicas.yaml
+  - path: patch-deploy-worker-replicas.yaml
+  - path: patch-ingress.yaml
+images:
+  - name: ghcr.io/alsairy/assets_platform/api
+    newTag: "{{VERSION}}"
+  - name: ghcr.io/alsairy/assets_platform/worker
+    newTag: "{{VERSION}}"
+configMapGenerator:
+  - name: assets-config
+    behavior: merge
+    literals:
+      - OIDC__AUTHORITY=https://idp.staging.example.com/realms/moe
+      - OIDC__AUDIENCE=assets-api
+      - Flowable__BaseUrl=https://flowable.staging.example.com/flowable-rest
+      - GoogleCloud__ProjectId=staging-gcp-project
+      - GCS__BucketName=staging-gcs-bucket

--- a/deploy/k8s/overlays/staging/netpol-allow-api-egress.yaml
+++ b/deploy/k8s/overlays/staging/netpol-allow-api-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: api
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/deploy/k8s/overlays/staging/netpol-allow-ingress-to-api.yaml
+++ b/deploy/k8s/overlays/staging/netpol-allow-ingress-to-api.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-api
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: api
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx

--- a/deploy/k8s/overlays/staging/netpol-allow-worker-egress.yaml
+++ b/deploy/k8s/overlays/staging/netpol-allow-worker-egress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-worker-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: assets
+      component: worker
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP

--- a/deploy/k8s/overlays/staging/netpol-default-deny-egress.yaml
+++ b/deploy/k8s/overlays/staging/netpol-default-deny-egress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/deploy/k8s/overlays/staging/patch-deploy-api-replicas.yaml
+++ b/deploy/k8s/overlays/staging/patch-deploy-api-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-api
+spec:
+  replicas: 2

--- a/deploy/k8s/overlays/staging/patch-deploy-worker-replicas.yaml
+++ b/deploy/k8s/overlays/staging/patch-deploy-worker-replicas.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: assets-worker
+spec:
+  replicas: 1

--- a/deploy/k8s/overlays/staging/patch-ingress.yaml
+++ b/deploy/k8s/overlays/staging/patch-ingress.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: assets-api
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: assets.staging.example.com
+  tls:
+    - hosts: ["assets.staging.example.com"]
+      secretName: assets-staging-tls

--- a/deploy/k8s/overlays/staging/pdb-api.yaml
+++ b/deploy/k8s/overlays/staging/pdb-api.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: assets-api
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: assets
+      component: api

--- a/deploy/k8s/overlays/staging/pdb-worker.yaml
+++ b/deploy/k8s/overlays/staging/pdb-worker.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: assets-worker
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: assets
+      component: worker

--- a/docs/deployment/capacity.md
+++ b/docs/deployment/capacity.md
@@ -1,0 +1,16 @@
+Capacity and scaling
+
+API
+- Requests: cpu 250m, memory 512Mi
+- HPA: CPU 70%, dev 1-2, staging 2-5, prod 3-10
+- PDB: minAvailable 1
+
+Worker
+- Requests: cpu 200m, memory 256Mi
+- HPA: CPU 70%, dev 1-2, staging 1-4, prod 2-8
+- PDB: minAvailable 1
+
+NetworkPolicy
+- Default deny egress
+- Allow ingress from ingress controller to API
+- Allow egress 443 for API and worker

--- a/docs/deployment/promotions.md
+++ b/docs/deployment/promotions.md
@@ -1,0 +1,10 @@
+Promotion workflow
+
+- Overlays: deploy/k8s/overlays/dev, staging, prod
+- CI injects VERSION from commit SHA into base images before rendering
+- Render and dry-run apply:
+  - kustomize build deploy/k8s/overlays/dev
+  - kustomize build deploy/k8s/overlays/staging
+  - kustomize build deploy/k8s/overlays/prod
+- Hosts and TLS secrets are set per overlay patch
+- Use immutable image tags (commit SHA) for promotion


### PR DESCRIPTION
Introduces kustomize base and overlays for dev/staging/prod

Adds HPA for API/worker, PDBs, and baseline NetworkPolicies

CI job renders manifests with VERSION (GITHUB_SHA) and validates via kubeconform

Docs for promotion and capacity

Link to Devin run: https://app.devin.ai/sessions/e4620343536744f1a9df1a838ee4be65

Requested by Abdulaziz AlSuayri (@Alsairy)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Kubernetes deployment setup for API and Worker: Deployments, Service, TLS Ingress, environment-specific HPAs, PDBs, and NetworkPolicies (default egress deny with DNS, ingress from nginx, 443 egress). Added ConfigMap/Secret configuration, resource limits, probes, and security hardening.
- Chores
  - Added CI job to render, validate, and publish environment manifests as artifacts.
- Documentation
  - Added capacity and scaling guide (resources, HPAs, PDBs, network policies).
  - Added promotion workflow detailing overlays, versioned images, and rendering steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->