### PR TITLE
chore(k8s): finishing touches (images ownership, config generator, HSTS, netpol, docs)

### DIFF
--- a/deploy/k8s/base/api-deployment.yaml
+++ b/deploy/k8s/base/api-deployment.yaml
@@ -59,7 +59,5 @@ spec:
             capabilities: { drop: ["ALL"] }
           volumeMounts:
             - { name: tmp,            mountPath: /tmp }
-            - { name: dataprotection, mountPath: /home/app/.aspnet/DataProtection-Keys }
       volumes:
         - { name: tmp,            emptyDir: {} }
-        - { name: dataprotection, emptyDir: {} }

--- a/deploy/k8s/base/ingress.yaml
+++ b/deploy/k8s/base/ingress.yaml
@@ -5,9 +5,6 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "20m"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/hsts: "true"
-    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
-    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
 spec:
   ingressClassName: nginx
   rules:

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
   - worker-deployment.yaml
   - api-service.yaml
   - ingress.yaml
-  - configmap.yaml
-  - secrets.template.yaml
 images:
   - name: ghcr.io/alsairy/assets_platform/api
     newName: ghcr.io/alsairy/assets_platform/api
@@ -14,3 +12,15 @@ images:
   - name: ghcr.io/alsairy/assets_platform/worker
     newName: ghcr.io/alsairy/assets_platform/worker
     newTag: "{{VERSION}}"
+configMapGenerator:
+  - name: assets-config
+    literals:
+      - OIDC__AUTHORITY=https://idp.example.com/realms/moe
+      - OIDC__AUDIENCE=assets-api
+      - Flowable__BaseUrl=https://flowable.example.com/flowable-rest
+      - OCR__PROVIDER=Google
+      - OCR__CONFIDENCETHRESHOLD=0.85
+      - GoogleCloud__ProjectId=your-gcp-project
+      - GCS__BucketName=your-gcs-bucket
+generatorOptions:
+  disableNameSuffixHash: false

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -15,11 +15,6 @@ patches:
   - path: patch-deploy-api-replicas.yaml
   - path: patch-deploy-worker-replicas.yaml
   - path: patch-ingress.yaml
-images:
-  - name: ghcr.io/alsairy/assets_platform/api
-    newTag: "{{VERSION}}"
-  - name: ghcr.io/alsairy/assets_platform/worker
-    newTag: "{{VERSION}}"
 configMapGenerator:
   - name: assets-config
     behavior: merge

--- a/deploy/k8s/overlays/dev/netpol-allow-api-egress.yaml
+++ b/deploy/k8s/overlays/dev/netpol-allow-api-egress.yaml
@@ -10,6 +10,18 @@ spec:
   policyTypes:
     - Egress
   egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
     - ports:
         - port: 443
           protocol: TCP

--- a/deploy/k8s/overlays/dev/netpol-allow-ingress-to-api.yaml
+++ b/deploy/k8s/overlays/dev/netpol-allow-ingress-to-api.yaml
@@ -14,3 +14,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx

--- a/deploy/k8s/overlays/dev/netpol-allow-worker-egress.yaml
+++ b/deploy/k8s/overlays/dev/netpol-allow-worker-egress.yaml
@@ -10,6 +10,18 @@ spec:
   policyTypes:
     - Egress
   egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
     - ports:
         - port: 443
           protocol: TCP

--- a/deploy/k8s/overlays/dev/patch-ingress.yaml
+++ b/deploy/k8s/overlays/dev/patch-ingress.yaml
@@ -6,6 +6,15 @@ spec:
   ingressClassName: nginx
   rules:
     - host: assets.dev.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: assets-api
+                port:
+                  number: 80
   tls:
     - hosts: ["assets.dev.example.com"]
       secretName: assets-dev-tls

--- a/deploy/k8s/overlays/prod/kustomization.yaml
+++ b/deploy/k8s/overlays/prod/kustomization.yaml
@@ -15,11 +15,6 @@ patches:
   - path: patch-deploy-api-replicas.yaml
   - path: patch-deploy-worker-replicas.yaml
   - path: patch-ingress.yaml
-images:
-  - name: ghcr.io/alsairy/assets_platform/api
-    newTag: "{{VERSION}}"
-  - name: ghcr.io/alsairy/assets_platform/worker
-    newTag: "{{VERSION}}"
 configMapGenerator:
   - name: assets-config
     behavior: merge

--- a/deploy/k8s/overlays/prod/netpol-allow-api-egress.yaml
+++ b/deploy/k8s/overlays/prod/netpol-allow-api-egress.yaml
@@ -10,6 +10,18 @@ spec:
   policyTypes:
     - Egress
   egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
     - ports:
         - port: 443
           protocol: TCP

--- a/deploy/k8s/overlays/prod/netpol-allow-ingress-to-api.yaml
+++ b/deploy/k8s/overlays/prod/netpol-allow-ingress-to-api.yaml
@@ -14,3 +14,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx

--- a/deploy/k8s/overlays/prod/netpol-allow-worker-egress.yaml
+++ b/deploy/k8s/overlays/prod/netpol-allow-worker-egress.yaml
@@ -10,6 +10,18 @@ spec:
   policyTypes:
     - Egress
   egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
     - ports:
         - port: 443
           protocol: TCP

--- a/deploy/k8s/overlays/prod/patch-ingress.yaml
+++ b/deploy/k8s/overlays/prod/patch-ingress.yaml
@@ -2,10 +2,23 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: assets-api
+  annotations:
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
 spec:
   ingressClassName: nginx
   rules:
     - host: assets.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: assets-api
+                port:
+                  number: 80
   tls:
     - hosts: ["assets.example.com"]
       secretName: assets-prod-tls

--- a/deploy/k8s/overlays/staging/kustomization.yaml
+++ b/deploy/k8s/overlays/staging/kustomization.yaml
@@ -15,11 +15,6 @@ patches:
   - path: patch-deploy-api-replicas.yaml
   - path: patch-deploy-worker-replicas.yaml
   - path: patch-ingress.yaml
-images:
-  - name: ghcr.io/alsairy/assets_platform/api
-    newTag: "{{VERSION}}"
-  - name: ghcr.io/alsairy/assets_platform/worker
-    newTag: "{{VERSION}}"
 configMapGenerator:
   - name: assets-config
     behavior: merge

--- a/deploy/k8s/overlays/staging/netpol-allow-api-egress.yaml
+++ b/deploy/k8s/overlays/staging/netpol-allow-api-egress.yaml
@@ -10,6 +10,18 @@ spec:
   policyTypes:
     - Egress
   egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
     - ports:
         - port: 443
           protocol: TCP

--- a/deploy/k8s/overlays/staging/netpol-allow-ingress-to-api.yaml
+++ b/deploy/k8s/overlays/staging/netpol-allow-ingress-to-api.yaml
@@ -14,3 +14,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx

--- a/deploy/k8s/overlays/staging/netpol-allow-worker-egress.yaml
+++ b/deploy/k8s/overlays/staging/netpol-allow-worker-egress.yaml
@@ -10,6 +10,18 @@ spec:
   policyTypes:
     - Egress
   egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
     - ports:
         - port: 443
           protocol: TCP

--- a/deploy/k8s/overlays/staging/patch-ingress.yaml
+++ b/deploy/k8s/overlays/staging/patch-ingress.yaml
@@ -6,6 +6,15 @@ spec:
   ingressClassName: nginx
   rules:
     - host: assets.staging.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: assets-api
+                port:
+                  number: 80
   tls:
     - hosts: ["assets.staging.example.com"]
       secretName: assets-staging-tls

--- a/docs/deployment/capacity.md
+++ b/docs/deployment/capacity.md
@@ -12,5 +12,6 @@ Worker
 
 NetworkPolicy
 - Default deny egress
-- Allow ingress from ingress controller to API
-- Allow egress 443 for API and worker
+- Allow ingress from ingress controller to API (namespaceSelector + podSelector for ingress-nginx)
+- Allow egress 443/TCP for API and worker
+- Allow DNS egress to kube-dns/coredns (UDP/TCP 53) for API and worker when default-deny egress is enabled

--- a/docs/deployment/promotions.md
+++ b/docs/deployment/promotions.md
@@ -1,10 +1,9 @@
 Promotion workflow
 
-- Overlays: deploy/k8s/overlays/dev, staging, prod
-- CI injects VERSION from commit SHA into base images before rendering
-- Render and dry-run apply:
-  - kustomize build deploy/k8s/overlays/dev
-  - kustomize build deploy/k8s/overlays/staging
-  - kustomize build deploy/k8s/overlays/prod
-- Hosts and TLS secrets are set per overlay patch
-- Use immutable image tags (commit SHA) for promotion
+- Base controls images and VERSION; overlays do not set images. CI injects VERSION (commit SHA) into base only before render.
+- Render and validate:
+  - kustomize build deploy/k8s/overlays/dev     | kubeconform -strict -summary -
+  - kustomize build deploy/k8s/overlays/staging | kubeconform -strict -summary -
+  - kustomize build deploy/k8s/overlays/prod    | kubeconform -strict -summary -
+- Hosts and TLS secrets are set per overlay patch; HSTS annotations only in prod.
+- Use immutable image tags (commit SHA) for promotion.


### PR DESCRIPTION
# chore(k8s): finishing touches (images ownership, config generator, HSTS, netpol, docs)

## Summary
This PR implements the "finishing touches" requested in code review to refine the Kubernetes configuration. Key changes include centralizing image tag control to the base layer, switching to configMapGenerator for automatic pod rolling updates, strengthening NetworkPolicies, and moving HSTS headers to production-only.

**Changes:**
- **Image management**: Removed `images:` blocks from overlays; base now controls all VERSION substitution 
- **Config rollouts**: Replaced static configmap.yaml with configMapGenerator to trigger pod restarts on config changes
- **Security hardening**: Added DNS egress rules and ingress-nginx podSelector to NetworkPolicies; moved HSTS annotations to prod overlay only
- **DataProtection cleanup**: Removed problematic emptyDir volume that gets wiped on pod restarts
- **Ingress fixes**: Added full http.paths blocks to overlay patches to prevent strategic merge issues
- **Documentation**: Updated deployment docs to reflect new image management and NetworkPolicy requirements

## Review & Testing Checklist for Human
- [ ] **Verify DNS NetworkPolicy labels match your cluster** - The egress rules assume `k8s-app: kube-dns` labels, but some clusters use `app.kubernetes.io/name: coredns`
- [ ] **Test auth functionality without DataProtection volume** - Verify cookie-based authentication still works after removing the emptyDir mount
- [ ] **Deploy to at least one environment end-to-end** - Confirm kustomize build works and pods start successfully with the new configMapGenerator
- [ ] **Validate HSTS behavior** - Ensure staging/dev environments work properly without HSTS headers, and prod has them applied correctly

### Notes
- ConfigMapGenerator will now restart pods whenever config values change (this is intentional for proper rollouts)
- The VERSION placeholder is now only substituted in base/kustomization.yaml by CI
- Static configmap.yaml and secrets.template.yaml have been removed from base resources

**Link to Devin run**: https://app.devin.ai/sessions/e4620343536744f1a9df1a838ee4be65  
**Requested by**: Abdulaziz AlSuayri (@Alsairy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added explicit HTTP path routing ("/" -> assets-api) for dev, staging, and prod ingresses.
- Security
  - HSTS enabled only in production; removed from base.
  - Tightened ingress policies to only allow ingress-nginx pods.
  - Added DNS egress rules (TCP/UDP 53) for API and worker to ensure name resolution under network policies.
- Refactor
  - Switched to generated config map for app settings; removed per-environment image overrides.
  - Removed unused DataProtection volume and adjusted base ingress annotations.
- Documentation
  - Updated promotion workflow and validation steps.
  - Clarified network policy requirements and HSTS usage per environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->