### PR TITLE
ci(deploy): staging/prod GitHub Actions with GKE OIDC, kustomize render/diff/apply, artifacts, and health checks

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,81 @@
+name: Deploy to Prod (GKE)
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Image/manifest VERSION (commit SHA) promoted from staging"
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  VERSION: ${{ github.event.inputs.sha }}
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+  WIF_SA_EMAIL: ${{ secrets.GCP_WIF_SA_EMAIL }}
+  GKE_CLUSTER: ${{ secrets.GKE_PROD_CLUSTER }}
+  GKE_LOCATION: ${{ secrets.GKE_PROD_LOCATION }}
+  NAMESPACE: assets-prod
+
+jobs:
+  deploy:
+    environment: production
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools (kustomize + kubectl + gcloud)
+        run: |
+          curl -sSL "https://github.com/kubernetes-sigs/kustomize/releases/latest/download/kustomize_linux_amd64.tar.gz" | tar -xz
+          sudo mv kustomize /usr/local/bin/
+          sudo apt-get update && sudo apt-get install -y google-cloud-cli
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SA_EMAIL }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER }}
+          location: ${{ env.GKE_LOCATION }}
+
+      - name: Render manifests (prod overlay) with VERSION
+        run: |
+          sed -i "s/{{VERSION}}/${VERSION}/g" deploy/k8s/base/kustomization.yaml
+          kustomize build deploy/k8s/overlays/prod > manifests-prod.yaml
+          git checkout -- deploy/k8s/base/kustomization.yaml
+
+      - name: Validate manifests with kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar -xz
+          sudo mv kubeconform /usr/local/bin/
+          kubeconform -strict -summary manifests-prod.yaml
+
+      - name: Diff
+        run: |
+          kubectl diff -n $NAMESPACE -f manifests-prod.yaml || true
+
+      - name: Apply (server-side & prune by label)
+        run: |
+          kubectl get ns $NAMESPACE >/dev/null 2>&1 || kubectl create ns $NAMESPACE
+          kubectl apply --server-side -n $NAMESPACE --prune -l app=assets -f manifests-prod.yaml
+
+      - name: Rollout checks
+        run: |
+          kubectl rollout status deploy -n $NAMESPACE -l app=assets --timeout=180s
+          kubectl wait --for=condition=Available deploy -n $NAMESPACE -l app=assets --timeout=120s
+
+      - name: Upload manifests artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifests-prod
+          path: manifests-prod.yaml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,80 @@
+name: Deploy to Staging (GKE)
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Image/manifest VERSION (commit SHA)"
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  VERSION: ${{ github.event.inputs.sha }}
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  WIF_PROVIDER: ${{ secrets.GCP_WIF_PROVIDER }}
+  WIF_SA_EMAIL: ${{ secrets.GCP_WIF_SA_EMAIL }}
+  GKE_CLUSTER: ${{ secrets.GKE_STAGING_CLUSTER }}
+  GKE_LOCATION: ${{ secrets.GKE_STAGING_LOCATION }}
+  NAMESPACE: assets-staging
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools (kustomize + kubectl + gcloud)
+        run: |
+          curl -sSL "https://github.com/kubernetes-sigs/kustomize/releases/latest/download/kustomize_linux_amd64.tar.gz" | tar -xz
+          sudo mv kustomize /usr/local/bin/
+          sudo apt-get update && sudo apt-get install -y google-cloud-cli
+
+      - name: Authenticate to GCP via Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SA_EMAIL }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER }}
+          location: ${{ env.GKE_LOCATION }}
+
+      - name: Render manifests (staging overlay) with VERSION
+        run: |
+          sed -i "s/{{VERSION}}/${VERSION}/g" deploy/k8s/base/kustomization.yaml
+          kustomize build deploy/k8s/overlays/staging > manifests-staging.yaml
+          git checkout -- deploy/k8s/base/kustomization.yaml
+
+      - name: Validate manifests with kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar -xz
+          sudo mv kubeconform /usr/local/bin/
+          kubeconform -strict -summary manifests-staging.yaml
+
+      - name: Diff
+        run: |
+          kubectl diff -n $NAMESPACE -f manifests-staging.yaml || true
+
+      - name: Apply (server-side & prune by label)
+        run: |
+          kubectl get ns $NAMESPACE >/dev/null 2>&1 || kubectl create ns $NAMESPACE
+          kubectl apply --server-side -n $NAMESPACE --prune -l app=assets -f manifests-staging.yaml
+
+      - name: Rollout checks
+        run: |
+          kubectl rollout status deploy -n $NAMESPACE -l app=assets --timeout=180s
+          kubectl wait --for=condition=Available deploy -n $NAMESPACE -l app=assets --timeout=120s
+
+      - name: Upload manifests artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifests-staging
+          path: manifests-staging.yaml

--- a/docs/deployment/promotions.md
+++ b/docs/deployment/promotions.md
@@ -1,9 +1,20 @@
 Promotion workflow
 
-- Base controls images and VERSION; overlays do not set images. CI injects VERSION (commit SHA) into base only before render.
+- Base controls images and VERSION; overlays do not set images. CI/workflow injects VERSION (commit SHA) into base before render.
 - Render and validate:
-  - kustomize build deploy/k8s/overlays/dev     | kubeconform -strict -summary -
   - kustomize build deploy/k8s/overlays/staging | kubeconform -strict -summary -
   - kustomize build deploy/k8s/overlays/prod    | kubeconform -strict -summary -
 - Hosts and TLS secrets are set per overlay patch; HSTS annotations only in prod.
 - Use immutable image tags (commit SHA) for promotion.
+
+Deployments
+
+- Staging: run “Deploy to Staging (GKE)” with sha set to the commit SHA that passed CI. The job authenticates via GCP Workload Identity Federation (OIDC), renders overlays/staging with VERSION=sha, runs kubectl diff, applies with server-side apply and prune (label app=assets), then waits for rollout.
+- Production: run “Deploy to Prod (GKE)” with the same sha used in staging. Environment protection provides manual approval. Same render/diff/apply/rollout flow.
+
+Rollback
+
+- kubectl -n assets-staging rollout undo deployment assets-api
+- kubectl -n assets-staging rollout undo deployment assets-worker
+- kubectl -n assets-prod rollout undo deployment assets-api
+- kubectl -n assets-prod rollout undo deployment assets-worker


### PR DESCRIPTION
What

Adds deploy-staging.yml and deploy-prod.yml to deploy to GKE using GitHub OIDC (Workload Identity Federation).

Renders kustomize overlays, validates with kubeconform, kubectl diff, server-side apply with prune, rollout checks.

Uploads rendered manifests as artifacts; prod requires manual approval via protected environment.

How

Injects VERSION (commit SHA) into deploy/k8s/base before rendering; overlays do not set images.

Auth via google-github-actions/auth + get-gke-credentials; kubectl apply -n assets-{staging,prod} with label prune (app=assets).

Docs

See docs/deployment/promotions.md for promotion and rollback steps.
Required repo secrets

GCP_PROJECT_ID, GCP_WIF_PROVIDER, GCP_WIF_SA_EMAIL

GKE_STAGING_CLUSTER, GKE_STAGING_LOCATION

GKE_PROD_CLUSTER, GKE_PROD_LOCATION

Rollback quick refs

kubectl -n assets-staging rollout undo deploy/assets-api; deploy/assets-worker

kubectl -n assets-prod rollout undo deploy/assets-api; deploy/assets-worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added manual GitHub Actions workflows to deploy to Staging and Production on GKE using a specified version, with validation, diff preview, server-side apply, and rollout checks. Generated manifests are archived as artifacts.

- Documentation
  - Updated deployment guide to reflect workflow-based VERSION injection and revised render/validate steps.
  - Added detailed Staging and Production deployment flows.
  - Introduced rollback instructions for core services.
  - Removed references to the dev overlay build step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->